### PR TITLE
fix: adopt report reference name

### DIFF
--- a/src/iec61850_client_connection.cpp
+++ b/src/iec61850_client_connection.cpp
@@ -492,7 +492,7 @@ IEC61850ClientConnection::m_configRcb ()
 
         IedConnection_installReportHandler (
             m_connection,
-            (rs->rcbRef.substr (0, rs->rcbRef.size () - 2)).c_str (),
+            (rs->rcbRef.substr (0, rs->rcbRef.size ())).c_str (),
             ClientReportControlBlock_getRptId (rcb), reportCallbackFunction,
             static_cast<void*> (connDataSetPair));
 


### PR DESCRIPTION
This fix is assuming report control blocks reference to be indexed and that this is correct.